### PR TITLE
Add type class to '<li>' tags in PageMenu like other Dokuwiki Themes

### DIFF
--- a/main.php
+++ b/main.php
@@ -74,7 +74,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 						<?php
 						$menu_items = (new \dokuwiki\Menu\UserMenu())->getItems();
 						foreach($menu_items as $item) {
-						echo '<li>'
+						echo '<li class="'.$item->getType().'">'
 							.'<a class="nav-link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
 							.'<i class="argon-doku-navbar-icon">'.inlineSVG($item->getSvg()).'</i>'
 							. '<span class="a11y">'.$item->getLabel().'</span>'
@@ -133,7 +133,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 									<?php
 									$menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
 									foreach($menu_items as $item) {
-									echo '<li>'
+									echo '<li class="'.$item->getType().'">'
 										.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
 										. $item->getLabel()
 										. '</a></li>';
@@ -152,7 +152,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 									<?php
 									$menu_items = (new \dokuwiki\Menu\SiteMenu())->getItems();
 									foreach($menu_items as $item) {
-									echo '<li>'
+									echo '<li class="'.$item->getType().'">'
 										.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
 										. $item->getLabel()
 										. '</a></li>';
@@ -248,7 +248,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 										<?php
 										$menu_items = (new \dokuwiki\Menu\MobileMenu())->getItems();
 										foreach($menu_items as $item) {
-										echo '<li>'
+										echo '<li class="'.$item->getType().'">'
 											.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
 											.'<i class="">'.inlineSVG($item->getSvg()).'</i>'
 											. '<span class="a11y">'.$item->getLabel().'</span>'


### PR DESCRIPTION
Other themes add the 'Type' atribute to the `<li>` tags, like so:

```
<li class="edit">
    <a href="/doku.php?id=test:start&amp;do=edit" title="Edit this page [e]" rel="nofollow" accesskey="e">
        <span>Edit this page</span>
        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="..."></path></svg>
    </a>
</li>
```

This attribute is used by some plugin's JavaScript to help identify an onclick event. By adding this attribute, it fixes those plugins and makes the format similar to other themes.

This theme currently does this:

```
<li>
    <a class="" href="/doku.php?id=test:start&amp;do=edit" title="Edit this page">
        Edit this page
    </a>
</li>
```

This commit makes it do this:
```
<li class="edit">
    <a class="" href="/doku.php?id=test:start&amp;do=edit" title="Edit this page">
        Edit this page
    </a>
</li>
```