### PR TITLE
Another Fix for PageMenu tags

### DIFF
--- a/main.php
+++ b/main.php
@@ -211,7 +211,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
                             <?php
                             $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
                             foreach($menu_items as $item) {
-                                echo '<li>'
+                                echo '<li class="'.$item->getType().'">'
                                     .'<a class="page-menu__link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
                                     .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
                                     . '<span class="a11y">'.$item->getLabel().'</span>'


### PR DESCRIPTION
Pull #20 added tags to PageMenu items to fix broken plugins. Then, my other pull #22 did not include this fix for the PageMenu on the main page. Oops.

This fixes that.