### PR TITLE
Add getLinkAttributes to PageTools

### DIFF
--- a/main.php
+++ b/main.php
@@ -134,7 +134,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
 									$menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
 									foreach($menu_items as $item) {
 									echo '<li class="'.$item->getType().'">'
-										.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
+										.'<a class="'.$item->getLinkAttributes('')['class'].'" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
 										. $item->getLabel()
 										. '</a></li>';
 									}
@@ -212,7 +212,7 @@ $showSidebar = page_findnearest($conf['sidebar']) && ($ACT == 'show');
                             $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
                             foreach($menu_items as $item) {
                                 echo '<li class="'.$item->getType().'">'
-                                    .'<a class="page-menu__link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
+                                    .'<a class="page-menu__link '.$item->getLinkAttributes('')['class'].'" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
                                     .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
                                     . '<span class="a11y">'.$item->getLabel().'</span>'
                                     . '</a></li>';


### PR DESCRIPTION
This fixes #25 

This add the `getLinkAttributes()` class to the PageMenu items `<a>` tags.

To use the plugin specifically mentioned in forementioned issue, it requires the class "plugin_move_page" in order to work. However, this template was not providing that. Here is the before and after:

### Before
```html
<a class="" href="/doku.php?id=start&amp;do=menuitem" title="Rename Page">Rename Page</a>
```

### After
```html
<a class="menuitem plugin_move_page " href="/doku.php?id=start&amp;do=menuitem" title="Rename Page">Rename Page</a>
```