### PR TITLE
Use function 'getListItems()' to build the menu list items

### DIFF
--- a/assets/css/doku.css
+++ b/assets/css/doku.css
@@ -24602,6 +24602,11 @@ pre > code.highlight {
   display: none;
 }
 
+.ct-sidenav a svg,
+.ct-navbar-nav a span {
+  display: none;
+}
+
 .ct-toc-link {
   display: block;
   padding: 0.25rem 1.5rem;
@@ -24812,6 +24817,9 @@ select {
 }
 .argon-doku-page-menu li:nth-of-type(1) {
   margin-left: 0em;
+}
+.argon-doku-page-menu li a span {
+  display: none;
 }
 
 #tool__bar button {

--- a/main.php
+++ b/main.php
@@ -87,15 +87,7 @@ $showIcon = tpl_getConf('showIcon');
 					<ul class="navbar-nav ct-navbar-nav flex-row align-items-center">
 
 						<?php
-						$menu_items = (new \dokuwiki\Menu\UserMenu())->getItems();
-						foreach($menu_items as $item) {
-						echo '<li class="'.$item->getType().'">'
-							.'<a class="nav-link" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-							.'<i class="argon-doku-navbar-icon" aria-hidden="true">'.inlineSVG($item->getSvg()).'</i>'
-							. '<span class="a11y">'.$item->getLabel().'</span>'
-							. '</a></li>';
-						}
-
+						echo (new \dokuwiki\Menu\UserMenu())->getListItems('action ');
 						?>
 
 
@@ -146,13 +138,7 @@ $showIcon = tpl_getConf('showIcon');
 								</a>
 								<ul class="nav ct-sidenav">
 									<?php
-									$menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
-									foreach($menu_items as $item) {
-									echo '<li class="'.$item->getType().'">'
-										.'<a class="'.$item->getLinkAttributes('')['class'].'" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-										. $item->getLabel()
-										. '</a></li>';
-									}
+									echo (new \dokuwiki\Menu\PageMenu())->getListItems();
 									?>
 								</ul>
 							</div>
@@ -165,14 +151,7 @@ $showIcon = tpl_getConf('showIcon');
 								</a>
 								<ul class="nav ct-sidenav">
 									<?php
-									$menu_items = (new \dokuwiki\Menu\SiteMenu())->getItems();
-									foreach($menu_items as $item) {
-									echo '<li class="'.$item->getType().'">'
-										.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-										. $item->getLabel()
-										. '</a></li>';
-									}
-
+									echo (new \dokuwiki\Menu\SiteMenu())->getListItems();
 									?>
 								</ul>
 							</div>
@@ -222,17 +201,10 @@ $showIcon = tpl_getConf('showIcon');
 
 						<?php if ($showTools && tpl_getConf('movePageTools')): ?>
 						<!-- Page Menu -->
-                        <div class="argon-doku-page-menu">
-                            <?php
-                            $menu_items = (new \dokuwiki\Menu\PageMenu())->getItems();
-                            foreach($menu_items as $item) {
-                                echo '<li class="'.$item->getType().'">'
-                                    .'<a class="page-menu__link '.$item->getLinkAttributes('')['class'].'" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-                                    .'<i class="">'.inlineSVG($item->getSvg()).'</i>'
-                                    . '<span class="a11y">'.$item->getLabel().'</span>'
-                                    . '</a></li>';
-                            }
-                            ?>
+						<div class="argon-doku-page-menu">
+							<?php
+							echo (new \dokuwiki\Menu\PageMenu())->getListItems();
+							?>
 						</div>
 						<?php endif;?>
 
@@ -244,7 +216,7 @@ $showIcon = tpl_getConf('showIcon');
 
 									<?php echo $buffer ?>
 								</div>
-							</div>							
+							</div>
 						</div>
 
 						<hr />
@@ -275,14 +247,7 @@ $showIcon = tpl_getConf('showIcon');
 									<div class="row">
 									<div class="argon-doku-footer-fullmenu">
 										<?php
-										$menu_items = (new \dokuwiki\Menu\MobileMenu())->getItems();
-										foreach($menu_items as $item) {
-										echo '<li class="'.$item->getType().'">'
-											.'<a class="" href="'.$item->getLink().'" title="'.$item->getTitle().'">'
-											.'<i class="" aria-hidden="true">'.inlineSVG($item->getSvg()).'</i>'
-											. '<span class="a11y">'.$item->getLabel().'</span>'
-											. '</a></li>';
-										}
+										echo (new \dokuwiki\Menu\MobileMenu())->getListItems();
 										?>
 									</div>
 									<?php tpl_includeFile('footer.html') ?>

--- a/main.php
+++ b/main.php
@@ -87,7 +87,7 @@ $showIcon = tpl_getConf('showIcon');
 					<ul class="navbar-nav ct-navbar-nav flex-row align-items-center">
 
 						<?php
-						echo (new \dokuwiki\Menu\UserMenu())->getListItems('action ');
+						echo (new \dokuwiki\Menu\UserMenu())->getListItems('argon-doku-navbar-icon nav-link ');
 						?>
 
 


### PR DESCRIPTION
This fixes the not working "fold/unfold all" button of the folded plugin. See https://github.com/dokufreaks/plugin-folded/issues/68.

I assume this might break some things. Not everything looks like before but some part of the menu look less broken. But it fixes the issue with the folded plugin and maybe (not tested) issues with other plugins which are triggered by the menu.

The issue with the folded plugin was caused because the a element did not have all attributes properly set. But it works with the standard DokuWiki template which calls ```getListItems()``` to build the menu and that is the reason why I used that function call in this PR.