### PR TITLE
Add Support for custom sidebar heading.

### DIFF
--- a/main.php
+++ b/main.php
@@ -187,7 +187,7 @@ $showIcon = tpl_getConf('showIcon');
 							<?php if ($showSidebar): ?>
 							<div id="dokuwiki__aside" class="ct-toc-item active">
 								<a class="ct-toc-link">
-									<?php echo "Sidebar" ?>
+									<?php echo $lang['sidebar'] ?>
 								</a>
 								<div class="leftsidebar">
 									<?php tpl_includeFile('sidebarheader.html')?>


### PR DESCRIPTION
I had to hunt for this for a while, as I'm new to Dockuwiki, and all of the solutions I found weren't working...because "Sidebar" was hard coded in the template.  But, the ability to customize this is important.  I added `$lang['sidebar'] = 'Document Library';` to a `lang.php` file in `/conf/lang/en` and then changed line 190 of your main.php to achieve the intended result.