### PR TITLE
Fix media align

### DIFF
--- a/assets/js/argon-design-system.min.js
+++ b/assets/js/argon-design-system.min.js
@@ -132,4 +132,18 @@ function debounce(t, o, r) {
         })
     }
 };
+
+function changeMedia() {
+    jQuery(".media>.mediaright").each(function() {
+        jQuery(this).parent().addClass("mediaright");
+        jQuery(this).parent().removeClass("media");
+    });
+    jQuery(".media>.medialeft").each(function() {
+        jQuery(this).parent().addClass("medialeft");
+        jQuery(this).parent().removeClass("media");
+    });
+}
+window.addEventListener("load", function() {
+    changeMedia();
+});
 //# sourceMappingURL=_site_kit_free/assets/js/kit-free.js.map


### PR DESCRIPTION
If you insert a right aligned image with a link, the image won't align correctly because the parent breaks the aligment.

This is a small fix for that.